### PR TITLE
fix(deploy): add MongoDB initialization script and update CI workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -100,7 +100,7 @@ jobs:
             docker-compose.yml
             deploy/docker-compose.prod.yml
             config/
-            docker-entrypoint-initdb.d/
+            docker-entrypoint-initdb.d/init-mongo.js
           target: ${{ secrets.DEPLOY_PATH }}
 
       - name: 🚀 Desplegar (SSH)

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@
 /dist
 /node_modules
 
-# Scripts locales
-/docker-entrypoint-initdb.d/init-mongo.js
-
 # Traefik ACME
 /data/traefik/acme/*
 !/data/traefik/acme/.gitkeep

--- a/docker-entrypoint-initdb.d/init-mongo.js
+++ b/docker-entrypoint-initdb.d/init-mongo.js
@@ -1,0 +1,17 @@
+// /docker-entrypoint-initdb.d/init-mongo.js
+
+db = db.getSiblingDB('imagedb');
+
+var collections = db.getCollectionNames();
+if (collections.length === 0) {
+  print("Inicializando base de datos por primera vez...");
+
+  db.createCollection('tasks');
+  db.tasks.createIndex({ "status": 1, "createdAt": -1 });
+  db.tasks.createIndex({ "createdAt": -1 });
+  db.tasks.createIndex({ "idempotencyKey": 1 }, { unique: true, sparse: true });
+
+  print("Índices creados exitosamente");
+} else {
+  print("Base de datos ya inicializada, saltando creación de índices");
+}


### PR DESCRIPTION
## Summary
Add MongoDB initialization script to the repository and update CI/CD workflow to handle deployment correctly.

## Changes
- Added `docker-entrypoint-initdb.d/init-mongo.js` with database initialization logic
- Updated `.gitignore` to track the MongoDB init script  
- Fixed CI workflow to properly copy required files during deployment

## Details
### MongoDB Initialization
- Creates `imagedb` database if not exists
- Sets up required indexes for `tasks` collection
- Implements idempotent initialization (safe to run multiple times)

### Workflow Updates  
- Removed unnecessary docker-entrypoint-initdb.d directory from SCP copy
- Added specific init-mongo.js file to deployment process

## Testing
- [x] MongoDB initializes correctly with indexes
- [x] CI/CD workflow completes successfully
- [x] Files are properly copied to deployment server

Fixes deployment issues with missing initialization scripts.